### PR TITLE
Fix command to add Brave repository in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,7 +692,7 @@ sudo dnf install -y mangohud
 
 ```bash
 sudo dnf install dnf-plugins-core
-sudo dnf config-manager --add-repo https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
+sudo dnf config-manager addrepo --from-repofile=https://brave-browser-rpm-release.s3.brave.com/brave-browser.repo
 sudo rpm --import https://brave-browser-rpm-release.s3.brave.com/brave-core.asc
 sudo dnf install -y brave-browser
 ```


### PR DESCRIPTION
Previous line results in output:
"Unknown argument "--add-repo" for command "config-manager". Add "--help" for more information about the arguments."

Updated with the correct line from source: https://brave.com/linux/